### PR TITLE
Fix infinite recursion when stubbing implicitly unwrapped optionals

### DIFF
--- a/MockItYourselfTests/StubTests.swift
+++ b/MockItYourselfTests/StubTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 import MockItYourself
 
+
 class StubTests: XCTestCase {
     
     var mockExample: MockExampleClass!
@@ -25,7 +26,7 @@ class StubTests: XCTestCase {
         XCTAssertEqual(actualReturn, MockExampleClass.defaultReturnValue)
     }
     
-    func test_can_stub_method_to_return_value() throws {
+    func test_can_stub_method_to_return_value() {
         let expectedReturn = "expected return"
         
         stub(mockExample, andReturnValue: expectedReturn) { self.mockExample.methodWithArgs1Returns("") }
@@ -34,11 +35,20 @@ class StubTests: XCTestCase {
         XCTAssertEqual(actualReturn, expectedReturn)
     }
     
-    func test_can_stub_property() throws {
+    func test_can_stub_property() {
         let expectedReturn = "expected return"
         
         stub(mockExample, andReturnValue: expectedReturn) { self.mockExample.property }
         let actualReturn = mockExample.property
+        
+        XCTAssertEqual(actualReturn, expectedReturn)
+    }
+    
+    func test_can_stub_implicitly_unwrapped_optional() {
+        let expectedReturn = "expected return"
+        
+        stub(mockExample, andReturnValue: expectedReturn) { self.mockExample.propertyImplicitlyUnwrapped }
+        let actualReturn = mockExample.propertyImplicitlyUnwrapped
         
         XCTAssertEqual(actualReturn, expectedReturn)
     }

--- a/MockItYourselfTests/StubTests.swift
+++ b/MockItYourselfTests/StubTests.swift
@@ -53,4 +53,10 @@ class StubTests: XCTestCase {
         XCTAssertEqual(actualReturn, expectedReturn)
     }
     
+    func test_can_stub_to_return_nil() {
+        stub(mockExample, andReturnValue: nil) { self.mockExample.propertyImplicitlyUnwrapped }
+        let actualReturn = mockExample.propertyImplicitlyUnwrapped
+        
+        XCTAssertEqual(actualReturn, nil)
+    }
 }

--- a/MockItYourselfTests/TestFixtures.swift
+++ b/MockItYourselfTests/TestFixtures.swift
@@ -12,6 +12,7 @@ import MockItYourself
 protocol ExampleProtocol {
     
     var property: String { get }
+    var propertyImplicitlyUnwrapped: String! { get }
     
     func methodThatIsNotMocked()
     
@@ -34,6 +35,10 @@ class MockExampleClass: ExampleProtocol, MockItYourself {
     static let defaultReturnValue = "default return value"
     
     var property: String {
+        return callHandler.registerCall(defaultReturnValue: MockExampleClass.defaultReturnValue)
+    }
+    
+    var propertyImplicitlyUnwrapped: String! {
         return callHandler.registerCall(defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
     


### PR DESCRIPTION
## Description

FIxes a bug when stubbing implicitly unwrapped properties that caused infinite recursion.

## Checklist

- [x] Documentation has been added or updated.
- [x] All applicable classes have unit tests.
- [x] This PR contains no commented out code.
