### PR TITLE
Make it possible to register call for method with AnyObject? argument

### DIFF
--- a/MockItYourself/MockArguments.swift
+++ b/MockItYourself/MockArguments.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Plain Vanilla Games. All rights reserved.
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 
 // This type only exists to complete the generics for the Arg type
@@ -63,6 +65,14 @@ public func arg(anyObject: AnyObject) -> Arg<AnyObject, AnyObjectArgument> {
     return Arg.AnyObject(anyObject)
 }
 
+public func arg(anyObject: AnyObject?) -> Arg<AnyObject, AnyObjectArgument> {
+    if let anyObject = anyObject {
+        return Arg.AnyObject(anyObject)
+    } else {
+        return Arg.Nil
+    }
+}
+
 public func arg(anyObjectList: [AnyObject]) -> Arg<AnyObject, AnyObjectArgument> {
     return Arg.AnyObject(anyObjectList as AnyObject)
 }
@@ -79,6 +89,14 @@ public func arg<A: Equatable>(equatable: A) -> Arg<AnyObject, A> {
     return Arg.Equatable(equatable)
 }
 
+public func arg<A: Equatable>(equatable: A?) -> Arg<AnyObject, A> {
+    if let equatable = equatable {
+        return Arg.Equatable(equatable)
+    } else {
+        return Arg.Nil
+    }
+}
+
 public func arg<A: Equatable>(list: [A]) -> Arg<AnyObject, A> {
     return Arg.List(list)
 }
@@ -90,14 +108,6 @@ public func arg<A, B>(dict: [A: B]) -> Arg<AnyObject, String> {
 
 public func arg<A, B>(dict: [A: B]?) -> Arg<AnyObject, String> {
     return arg(dict ?? [:])
-}
-
-public func arg<A: Equatable>(equatable: A?) -> Arg<AnyObject, A> {
-    if let equatable = equatable {
-        return Arg.Equatable(equatable)
-    } else {
-        return Arg.Nil
-    }
 }
 
 // MARK: Args0

--- a/MockItYourselfTests/TestFixtures.swift
+++ b/MockItYourselfTests/TestFixtures.swift
@@ -93,4 +93,8 @@ class MockExampleClass: ExampleProtocol, MockItYourself {
     func methodWithArgs2(arg1: AnyObject, arg2: Selector) -> String {
         return callHandler.registerCall(args: Args2(arg(arg1), arg(arg2)), defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
+    
+    func methodWithArgs3(arg1: AnyObject?, arg2: Selector, arg3: Int) -> String {
+        return callHandler.registerCall(args: Args3(arg(arg1), arg(arg2), arg(arg3)), defaultReturnValue: MockExampleClass.defaultReturnValue)
+    }
 }


### PR DESCRIPTION
## Description

Fixes bug which made it impossible to register call with AnyObject? argument. We were simply missing an `arg` implementation for `AnyObject?`.

## Checklist

- [x] Documentation has been added or updated.
- [x] All applicable classes have unit tests.
- [x] This PR contains no commented out code.