### PR TITLE
Fix mismatch of return value of stub

### DIFF
--- a/MockItYourself/MockCallHandler.swift
+++ b/MockItYourself/MockCallHandler.swift
@@ -127,7 +127,7 @@ public class MockCallHandler {
         }
     }
 
-    func verify(expectedCallCount expectedCallCount: Int? = nil, checkArguments: Bool = false, method: () -> ()) throws {
+    func verify(expectedCallCount expectedCallCount: Int? = nil, checkArguments: Bool = true, method: () -> ()) throws {
         let methodName = try captureMethodCall(method)
         
         if let callHistory = recordedCalls[methodName] {

--- a/MockItYourself/MockItYourself.swift
+++ b/MockItYourself/MockItYourself.swift
@@ -13,23 +13,9 @@ public protocol MockItYourself {
     var callHandler: MockCallHandler { get }
 }
 
-extension MockItYourself {
-    func verify(expectedCallCount expectedCallCount: Int? = nil, checkArguments: Bool = true, method: () -> ()) throws {
-        try callHandler.verify(expectedCallCount: expectedCallCount, checkArguments: checkArguments, method: method)
-    }
-    
-    func reject(method: () -> ()) throws {
-        try callHandler.reject(method)
-    }
-    
-    func stub(method: () -> (), andReturnValue returnValue: Any?, checkArguments: Bool = true) throws {
-        try callHandler.stub(method, andReturnValue: returnValue, checkArguments: checkArguments)
-    }
-}
-
 public func verify(mock: MockItYourself, message: String = "", file: StaticString = #file, line: UInt = #line, expectedCallCount: Int? = nil, checkArguments: Bool = true, verify: () -> ()) {
     do {
-        try mock.verify(expectedCallCount: expectedCallCount, checkArguments: checkArguments, method: verify)
+        try mock.callHandler.verify(expectedCallCount: expectedCallCount, checkArguments: checkArguments, method: verify)
     } catch let error {
         XCTFail("\(error)", file:  file, line: line)
     }
@@ -37,7 +23,7 @@ public func verify(mock: MockItYourself, message: String = "", file: StaticStrin
 
 public func reject(mock: MockItYourself, message: String = "", file: StaticString = #file, line: UInt = #line, reject: () -> ()) {
     do {
-        try mock.reject(reject)
+        try mock.callHandler.reject(reject)
     } catch let error {
         XCTFail("\(error)", file:  file, line: line)
     }
@@ -45,7 +31,7 @@ public func reject(mock: MockItYourself, message: String = "", file: StaticStrin
 
 public func stub(mock: MockItYourself, andReturnValue returnValue: Any?, checkArguments: Bool = true, file: StaticString = #file, line: UInt = #line, method: () -> ()) {
      do {
-        try mock.stub(method, andReturnValue: returnValue, checkArguments: checkArguments)
+        try mock.callHandler.stub(method, andReturnValue: returnValue, checkArguments: checkArguments)
      } catch let error {
         XCTFail("\(error)", file:  file, line: line)
     }

--- a/MockItYourself/MockItYourself.swift
+++ b/MockItYourself/MockItYourself.swift
@@ -29,10 +29,18 @@ public func reject(mock: MockItYourself, message: String = "", file: StaticStrin
     }
 }
 
-public func stub(mock: MockItYourself, andReturnValue returnValue: Any?, checkArguments: Bool = true, file: StaticString = #file, line: UInt = #line, method: () -> ()) {
+public func stub<R>(mock: MockItYourself, andReturnValue returnValue: R, checkArguments: Bool = true, file: StaticString = #file, line: UInt = #line, method: () -> R) {
      do {
-        try mock.callHandler.stub(method, andReturnValue: returnValue, checkArguments: checkArguments)
+        try mock.callHandler.stub({ method() }, andReturnValue: returnValue, checkArguments: checkArguments)
      } catch let error {
+        XCTFail("\(error)", file:  file, line: line)
+    }
+}
+
+public func stub<R>(mock: MockItYourself, andReturnValue returnValue: R?, checkArguments: Bool = true, file: StaticString = #file, line: UInt = #line, method: () -> R?) {
+    do {
+        try mock.callHandler.stub({ method() }, andReturnValue: returnValue, checkArguments: checkArguments)
+    } catch let error {
         XCTFail("\(error)", file:  file, line: line)
     }
 }

--- a/MockItYourselfTests/RejectTests.swift
+++ b/MockItYourselfTests/RejectTests.swift
@@ -22,7 +22,7 @@ class RejectTests: XCTestCase {
         var success = false
         
         do {
-            try mockExample.reject() { self.mockExample.methodThatIsNotMocked() }
+            try mockExample.callHandler.reject() { self.mockExample.methodThatIsNotMocked() }
         } catch {
             success = true
         }
@@ -40,7 +40,7 @@ class RejectTests: XCTestCase {
         var success = false
         
         do {
-            try mockExample.reject() { self.mockExample.methodWithArgs1("") }
+            try mockExample.callHandler.reject() { self.mockExample.methodWithArgs1("") }
         } catch {
             success = true
         }

--- a/MockItYourselfTests/StubTests.swift
+++ b/MockItYourselfTests/StubTests.swift
@@ -65,7 +65,7 @@ class StubTests: XCTestCase {
         
         var success = false
         do {
-            try mockExample.stub({ self.mockExample.methodWithArgs1Returns("B") }, andReturnValue: "Return B", checkArguments: true)
+            try mockExample.callHandler.stub({ self.mockExample.methodWithArgs1Returns("B") }, andReturnValue: "Return B", checkArguments: true)
         } catch MockVerificationError.MethodHasBeenStubbedForAllArguments {
             success = true
         } catch {

--- a/MockItYourselfTests/VerifyTests.swift
+++ b/MockItYourselfTests/VerifyTests.swift
@@ -22,7 +22,7 @@ class VerifyTests: XCTestCase {
         var success = false
         
         do {
-            try mockExample.verify() { self.mockExample.methodThatIsNotMocked() }
+            try mockExample.callHandler.verify() { self.mockExample.methodThatIsNotMocked() }
         } catch {
             success = true
         }
@@ -49,7 +49,7 @@ class VerifyTests: XCTestCase {
         mockExample.methodWithArgs0()
         
         do {
-            try mockExample.verify(expectedCallCount: 2) { self.mockExample.methodWithArgs0() }
+            try mockExample.callHandler.verify(expectedCallCount: 2) { self.mockExample.methodWithArgs0() }
         } catch {
             success = true
         }
@@ -76,7 +76,7 @@ class VerifyTests: XCTestCase {
         var success = false
         
         do {
-            try mockExample.verify() { self.mockExample.methodWithArgs2(any(), arg2: nil) }
+            try mockExample.callHandler.verify() { self.mockExample.methodWithArgs2(any(), arg2: nil) }
         } catch {
             success = true
         }
@@ -111,7 +111,7 @@ class VerifyTests: XCTestCase {
         
         var success = false
         do {
-            try mockExample.verify(checkArguments: true, expectedCallCount: 2) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
+            try mockExample.callHandler.verify(checkArguments: true, expectedCallCount: 2) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
         } catch {
             success = true
         }
@@ -128,7 +128,7 @@ class VerifyTests: XCTestCase {
         
         var success = false
         do {
-            try mockExample.verify(checkArguments: true, expectedCallCount: 2) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
+            try mockExample.callHandler.verify(checkArguments: true, expectedCallCount: 2) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
         } catch {
             success = true
         }
@@ -151,7 +151,7 @@ class VerifyTests: XCTestCase {
         var success = false
         
         do {
-            try mockExample.verify(checkArguments: true) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
+            try mockExample.callHandler.verify(checkArguments: true) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
         } catch {
             success = true
         }
@@ -168,7 +168,7 @@ class VerifyTests: XCTestCase {
         var success = false
         
         do {
-            try mockExample.verify(checkArguments: true) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
+            try mockExample.callHandler.verify(checkArguments: true) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
         } catch {
             success = true
         }


### PR DESCRIPTION
## Description

Makes it impossible to return the wrong type from stub.

## Checklist

- [x] Documentation has been added or updated.
- [x] All applicable classes have unit tests.
- [x] This PR contains no commented out code.
