### PR TITLE
Basic Swift 3.0 support

### DIFF
--- a/MockItYourself.xcodeproj/project.pbxproj
+++ b/MockItYourself.xcodeproj/project.pbxproj
@@ -306,7 +306,6 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -359,7 +358,6 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -390,6 +388,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -414,6 +413,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -462,7 +462,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -504,7 +503,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/MockItYourself.xcodeproj/project.pbxproj
+++ b/MockItYourself.xcodeproj/project.pbxproj
@@ -306,7 +306,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -359,7 +359,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 2.3;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/MockItYourself/MockArguments.swift
+++ b/MockItYourself/MockArguments.swift
@@ -21,21 +21,21 @@ public func == (lhs: AnyObjectArgument, rhs: AnyObjectArgument) -> Bool {
 // Mark: Arg
 
 public enum Arg<A: AnyObject, B: Equatable> : Equatable {
-    case AnyObject(A)
-    case Equatable(B)
-    case List([B])
-    case Nil
+    case anyObject(A)
+    case equatable(B)
+    case list([B])
+    case `nil`
 }
 
 public func ==<A: AnyObject, B: Equatable>(lhs: Arg<A, B>, rhs: Arg<A, B>) -> Bool {
     switch (lhs, rhs) {
-    case (.AnyObject(let x), .AnyObject(let y)):
+    case (.anyObject(let x), .anyObject(let y)):
         return x == y
-    case (.Equatable(let x), .Equatable(let y)):
+    case (.equatable(let x), .equatable(let y)):
         return x == y
-    case (.List(let x), .List(let y)):
+    case (.list(let x), .list(let y)):
         return x == y
-    case (.Nil, .Nil):
+    case (.nil, .nil):
         return true
     default:
         return false
@@ -62,48 +62,48 @@ func == (lhs: AnyObject, rhs: AnyObject) -> Bool {
 }
 
 public func arg(anyObject: AnyObject) -> Arg<AnyObject, AnyObjectArgument> {
-    return Arg.AnyObject(anyObject)
+    return Arg.anyObject(anyObject)
 }
 
 public func arg(anyObject: AnyObject?) -> Arg<AnyObject, AnyObjectArgument> {
     if let anyObject = anyObject {
-        return Arg.AnyObject(anyObject)
+        return Arg.anyObject(anyObject)
     } else {
-        return Arg.Nil
+        return Arg.nil
     }
 }
 
 public func arg(anyObjectList: [AnyObject]) -> Arg<AnyObject, AnyObjectArgument> {
-    return Arg.AnyObject(anyObjectList as AnyObject)
+    return Arg.anyObject(anyObjectList as AnyObject)
 }
 
 public func arg(anyObjectList: [AnyObject]?) -> Arg<AnyObject, AnyObjectArgument> {
-    return Arg.AnyObject((anyObjectList ?? []) as AnyObject)
+    return Arg.anyObject((anyObjectList ?? []) as AnyObject)
 }
 
 public func arg(anyClass: AnyClass) -> Arg<AnyObject, AnyObjectArgument> {
-    return Arg.AnyObject(anyClass)
+    return Arg.anyObject(anyClass)
 }
 
 public func arg<A: Equatable>(equatable: A) -> Arg<AnyObject, A> {
-    return Arg.Equatable(equatable)
+    return Arg.equatable(equatable)
 }
 
 public func arg<A: Equatable>(equatable: A?) -> Arg<AnyObject, A> {
     if let equatable = equatable {
-        return Arg.Equatable(equatable)
+        return Arg.equatable(equatable)
     } else {
-        return Arg.Nil
+        return Arg.nil
     }
 }
 
 public func arg<A: Equatable>(list: [A]) -> Arg<AnyObject, A> {
-    return Arg.List(list)
+    return Arg.list(list)
 }
 
 public func arg<A, B>(dict: [A: B]) -> Arg<AnyObject, String> {
     let flattened = dict.map({"\($0):\($1)"})
-    return Arg.List(flattened)
+    return Arg.list(flattened)
 }
 
 public func arg<A, B>(dict: [A: B]?) -> Arg<AnyObject, String> {

--- a/MockItYourself/MockArguments.swift
+++ b/MockItYourself/MockArguments.swift
@@ -61,11 +61,11 @@ func == (lhs: AnyObject, rhs: AnyObject) -> Bool {
     }
 }
 
-public func arg(anyObject: AnyObject) -> Arg<AnyObject, AnyObjectArgument> {
+public func arg(_ anyObject: AnyObject) -> Arg<AnyObject, AnyObjectArgument> {
     return Arg.anyObject(anyObject)
 }
 
-public func arg(anyObject: AnyObject?) -> Arg<AnyObject, AnyObjectArgument> {
+public func arg(_ anyObject: AnyObject?) -> Arg<AnyObject, AnyObjectArgument> {
     if let anyObject = anyObject {
         return Arg.anyObject(anyObject)
     } else {
@@ -73,7 +73,7 @@ public func arg(anyObject: AnyObject?) -> Arg<AnyObject, AnyObjectArgument> {
     }
 }
 
-public func arg(anyObjectList: [AnyObject]) -> Arg<AnyObject, AnyObjectArgument> {
+public func arg(_ anyObjectList: [AnyObject]) -> Arg<AnyObject, AnyObjectArgument> {
     return Arg.anyObject(anyObjectList as AnyObject)
 }
 
@@ -85,11 +85,11 @@ public func arg(anyClass: AnyClass) -> Arg<AnyObject, AnyObjectArgument> {
     return Arg.anyObject(anyClass)
 }
 
-public func arg<A: Equatable>(equatable: A) -> Arg<AnyObject, A> {
+public func arg<A: Equatable>(_ equatable: A) -> Arg<AnyObject, A> {
     return Arg.equatable(equatable)
 }
 
-public func arg<A: Equatable>(equatable: A?) -> Arg<AnyObject, A> {
+public func arg<A: Equatable>(_ equatable: A?) -> Arg<AnyObject, A> {
     if let equatable = equatable {
         return Arg.equatable(equatable)
     } else {
@@ -97,17 +97,17 @@ public func arg<A: Equatable>(equatable: A?) -> Arg<AnyObject, A> {
     }
 }
 
-public func arg<A: Equatable>(list: [A]) -> Arg<AnyObject, A> {
+public func arg<A: Equatable>(_ list: [A]) -> Arg<AnyObject, A> {
     return Arg.list(list)
 }
 
-public func arg<A, B>(dict: [A: B]) -> Arg<AnyObject, String> {
+public func arg<A, B>(_ dict: [A: B]) -> Arg<AnyObject, String> {
     let flattened = dict.map({"\($0):\($1)"})
     return Arg.list(flattened)
 }
 
-public func arg<A, B>(dict: [A: B]?) -> Arg<AnyObject, String> {
-    return arg(dict: dict ?? [:])
+public func arg<A, B>(_ dict: [A: B]?) -> Arg<AnyObject, String> {
+    return arg(dict ?? [:])
 }
 
 // MARK: Args0

--- a/MockItYourself/MockArguments.swift
+++ b/MockItYourself/MockArguments.swift
@@ -107,7 +107,7 @@ public func arg<A, B>(dict: [A: B]) -> Arg<AnyObject, String> {
 }
 
 public func arg<A, B>(dict: [A: B]?) -> Arg<AnyObject, String> {
-    return arg(dict ?? [:])
+    return arg(dict: dict ?? [:])
 }
 
 // MARK: Args0

--- a/MockItYourself/MockCallHandler.swift
+++ b/MockItYourself/MockCallHandler.swift
@@ -40,7 +40,7 @@ public class MockCallHandler {
         return methodCallName
     }
 
-    public func registerCall(methodName: String = #function) {
+    public func registerMethodCall(methodName: String = #function) {
         registerCall(args: Args0(), methodName: methodName)
     }
     

--- a/MockItYourself/MockCallHandler.swift
+++ b/MockItYourself/MockCallHandler.swift
@@ -64,7 +64,7 @@ public class MockCallHandler {
             break
         }
         
-        if let recordedStubs = stubs[methodName] as? StubRegistryRecorder<A>, stub = recordedStubs.getStubbedValue(args: args) {
+        if let recordedStubs = stubs[methodName] as? StubRegistryRecorder<A>, let stub = recordedStubs.getStubbedValue(args: args) {
             return stub.value as? R
         } else {
             return defaultReturnValue
@@ -87,7 +87,7 @@ public class MockCallHandler {
             break
         }
         
-        if let recordedStubs = stubs[methodName] as? StubRegistryRecorder<A>, stub = recordedStubs.getStubbedValue(args) {
+        if let recordedStubs = stubs[methodName] as? StubRegistryRecorder<A>, let stub = recordedStubs.getStubbedValue(args: args) {
             if let stubbedValue = stub.value {
                 return stubbedValue as! R
             } else {

--- a/MockItYourself/MockCallHandler.swift
+++ b/MockItYourself/MockCallHandler.swift
@@ -258,7 +258,7 @@ class StubRegistryRecorder<A: Equatable>: StubRegistry {
     }
 }
 
-enum MockVerificationError: ErrorType {
+enum MockVerificationError: Error {
     case MethodNotCalled
     case MethodWasCalled
     case MethodCallCountMismatch(Int, Int)

--- a/MockItYourself/MockCallHandler.swift
+++ b/MockItYourself/MockCallHandler.swift
@@ -48,12 +48,10 @@ public class MockCallHandler {
         recordCall(methodName: methodName, args: args)
     }
     
-    @warn_unused_result(message="Did you mean to call `registerCall` that doesn't return a value?")
     public func registerCall<R: Any>(defaultReturnValue defaultReturnValue: R?, methodName: String = #function) -> R? {
         return registerCall(args: Args0(), defaultReturnValue: defaultReturnValue, methodName: methodName)
     }
     
-    @warn_unused_result(message="Did you mean to call `registerCall` that doesn't return a value?")
     public func registerCall<A: Equatable, R: Any>(args args: A, defaultReturnValue: R?, methodName: String = #function) -> R? {
         let methodName = recordCall(methodName: methodName, args: args)
         
@@ -73,12 +71,10 @@ public class MockCallHandler {
         }
     }
 
-    @warn_unused_result(message="Did you mean to call `registerCall` that doesn't return a value?")
     public func registerCall<R: Any>(defaultReturnValue defaultReturnValue: R, methodName: String = #function) -> R {
         return registerCall(args: Args0(), defaultReturnValue: defaultReturnValue, methodName: methodName)
     }
-    
-    @warn_unused_result(message="Did you mean to call `registerCall` that doesn't return a value?")
+
     public func registerCall<A: Equatable, R: Any>(args args: A, defaultReturnValue: R, methodName: String = #function) -> R {
         let methodName = recordCall(methodName: methodName, args: args)
         

--- a/MockItYourself/MockCallHandler.swift
+++ b/MockItYourself/MockCallHandler.swift
@@ -45,7 +45,7 @@ public class MockCallHandler {
     }
     
     public func registerCall<A: Equatable>(args: A, methodName: String = #function) {
-        recordCall(methodName: methodName, args: args)
+        _ = recordCall(methodName: methodName, args: args)
     }
     
     public func registerCall<R: Any>(defaultReturnValue: R?, methodName: String = #function) -> R? {
@@ -128,7 +128,7 @@ public class MockCallHandler {
         
         if let callHistory = recordedCalls[methodName] {
             if let expectedCallCount = expectedCallCount {
-                let actualCallCount = callHistory.count ?? 0
+                let actualCallCount = callHistory.count 
                 if expectedCallCount != actualCallCount {
                     throw MockVerificationError.MethodCallCountMismatch(actualCallCount, expectedCallCount)
                 }

--- a/MockItYourself/MockCallHandler.swift
+++ b/MockItYourself/MockCallHandler.swift
@@ -242,12 +242,12 @@ class StubRegistryRecorder<A: Equatable>: StubRegistry {
     
     func removePreviousStubForArgsIfAny(args: A) {
         if getStubbedValue(args) != nil {
-            let indexOfPreviousStub = stubs.indexOf({ (argsI, stubI) in
+            let indexOfPreviousStub = stubs.index(where: { (argsI, stubI) in
                 return argsI == args
             })
             
             if let indexOfPreviousStub = indexOfPreviousStub {
-                stubs.removeAtIndex(indexOfPreviousStub)
+                stubs.remove(at: indexOfPreviousStub)
             }
         }
     }

--- a/MockItYourself/MockItYourself.swift
+++ b/MockItYourself/MockItYourself.swift
@@ -13,7 +13,7 @@ public protocol MockItYourself {
     var callHandler: MockCallHandler { get }
 }
 
-public func verify(mock: MockItYourself, message: String = "", file: StaticString = #file, line: UInt = #line, expectedCallCount: Int? = nil, checkArguments: Bool = true, verify: () -> ()) {
+public func verify(_ mock: MockItYourself, message: String = "", file: StaticString = #file, line: UInt = #line, expectedCallCount: Int? = nil, checkArguments: Bool = true, verify: () -> ()) {
     do {
         try mock.callHandler.verify(expectedCallCount: expectedCallCount, checkArguments: checkArguments, method: verify)
     } catch let error {
@@ -21,7 +21,7 @@ public func verify(mock: MockItYourself, message: String = "", file: StaticStrin
     }
 }
 
-public func reject(mock: MockItYourself, message: String = "", file: StaticString = #file, line: UInt = #line, reject: () -> ()) {
+public func reject(_ mock: MockItYourself, message: String = "", file: StaticString = #file, line: UInt = #line, reject: () -> ()) {
     do {
         try mock.callHandler.reject(reject)
     } catch let error {
@@ -29,7 +29,7 @@ public func reject(mock: MockItYourself, message: String = "", file: StaticStrin
     }
 }
 
-public func stub<R>(mock: MockItYourself, andReturnValue returnValue: R, checkArguments: Bool = true, file: StaticString = #file, line: UInt = #line, method: () -> R) {
+public func stub<R>(_ mock: MockItYourself, andReturnValue returnValue: R, checkArguments: Bool = true, file: StaticString = #file, line: UInt = #line, method: () -> R) {
      do {
         try mock.callHandler.stub({ method() }, andReturnValue: returnValue, checkArguments: checkArguments)
      } catch let error {
@@ -37,7 +37,7 @@ public func stub<R>(mock: MockItYourself, andReturnValue returnValue: R, checkAr
     }
 }
 
-public func stub<R>(mock: MockItYourself, andReturnValue returnValue: R?, checkArguments: Bool = true, file: StaticString = #file, line: UInt = #line, method: () -> R?) {
+public func stub<R>(_ mock: MockItYourself, andReturnValue returnValue: R?, checkArguments: Bool = true, file: StaticString = #file, line: UInt = #line, method: () -> R?) {
     do {
         try mock.callHandler.stub({ method() }, andReturnValue: returnValue, checkArguments: checkArguments)
     } catch let error {

--- a/MockItYourself/MockItYourself.swift
+++ b/MockItYourself/MockItYourself.swift
@@ -31,7 +31,7 @@ public func reject(_ mock: MockItYourself, message: String = "", file: StaticStr
 
 public func stub<R>(_ mock: MockItYourself, andReturnValue returnValue: R, checkArguments: Bool = true, file: StaticString = #file, line: UInt = #line, method: () -> R) {
      do {
-        try mock.callHandler.stub({ method() }, andReturnValue: returnValue, checkArguments: checkArguments)
+        try mock.callHandler.stub({ _ = method() }, andReturnValue: returnValue, checkArguments: checkArguments)
      } catch let error {
         XCTFail("\(error)", file:  file, line: line)
     }
@@ -39,7 +39,7 @@ public func stub<R>(_ mock: MockItYourself, andReturnValue returnValue: R, check
 
 public func stub<R>(_ mock: MockItYourself, andReturnValue returnValue: R?, checkArguments: Bool = true, file: StaticString = #file, line: UInt = #line, method: () -> R?) {
     do {
-        try mock.callHandler.stub({ method() }, andReturnValue: returnValue, checkArguments: checkArguments)
+        try mock.callHandler.stub({ _ = method() }, andReturnValue: returnValue, checkArguments: checkArguments)
     } catch let error {
         XCTFail("\(error)", file:  file, line: line)
     }

--- a/MockItYourselfTests/StubTests.swift
+++ b/MockItYourselfTests/StubTests.swift
@@ -65,7 +65,7 @@ class StubTests: XCTestCase {
         
         var success = false
         do {
-            try mockExample.callHandler.stub({ self.mockExample.methodWithArgs1Returns("B") }, andReturnValue: "Return B", checkArguments: true)
+            try mockExample.callHandler.stub({ _ = self.mockExample.methodWithArgs1Returns("B") }, andReturnValue: "Return B", checkArguments: true)
         } catch MockVerificationError.MethodHasBeenStubbedForAllArguments {
             success = true
         } catch {

--- a/MockItYourselfTests/TestFixtures.swift
+++ b/MockItYourselfTests/TestFixtures.swift
@@ -24,17 +24,17 @@ protocol ExampleProtocol {
     
     func methodThatIsNotMocked()
     
-    func methodWithOptionalArgument(arg1: String?)
+    func methodWithOptionalArgument(_ arg1: String?)
     
     func methodWithArgs0()
     func methodWithArgs0ReturnsOptional() -> String?
     func methodWithArgs0Returns() -> String
     
-    func methodWithArgs1(arg1: String)
-    func methodWithArgs1ReturnsOptional(arg1: String) -> String?
-    func methodWithArgs1Returns(arg1: String) -> String
+    func methodWithArgs1(_ arg1: String)
+    func methodWithArgs1ReturnsOptional(_ arg1: String) -> String?
+    func methodWithArgs1Returns(_ arg1: String) -> String
     
-    func methodWithArgs2(arg1: AnyObject, arg2: Selector) -> String
+    func methodWithArgs2(_ arg1: AnyObject, arg2: Selector) -> String
 }
 
 class MockExampleClass: ExampleProtocol, MockItYourself {
@@ -58,10 +58,10 @@ class MockExampleClass: ExampleProtocol, MockItYourself {
         //Not mocked method
     }
     
-    func methodWithOptionalArgument(arg1: String?) {
+    func methodWithOptionalArgument(_ arg1: String?) {
         callHandler.registerCall(args: Args1(arg(arg1)))
     }
-    
+
     func methodWithArgs0() {
         callHandler.registerCall()
     }
@@ -74,11 +74,11 @@ class MockExampleClass: ExampleProtocol, MockItYourself {
         return callHandler.registerCall(defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
     
-    func methodWithArgs1(arg1: String) {
+    func methodWithArgs1(_ arg1: String) {
         callHandler.registerCall(args: Args1(arg(arg1)))
     }
     
-    func methodWithArgs1ReturnsOptional(arg1: String) -> String? {
+    func methodWithArgs1ReturnsOptional(_ arg1: String) -> String? {
         return callHandler.registerCall(args: Args1(arg(arg1)), defaultReturnValue: nil)
     }
     
@@ -86,11 +86,11 @@ class MockExampleClass: ExampleProtocol, MockItYourself {
         return callHandler.registerCall(args: Args1(arg(arg1)), defaultReturnValue: ReturnValueClass(value: 1))
     }
     
-    func methodWithArgs1Returns(arg1: String) -> String {
+    func methodWithArgs1Returns(_ arg1: String) -> String {
         return callHandler.registerCall(args: Args1(arg(arg1)), defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
     
-    func methodWithArgs2(arg1: AnyObject, arg2: Selector) -> String {
+    func methodWithArgs2(_ arg1: AnyObject, arg2: Selector) -> String {
         return callHandler.registerCall(args: Args2(arg(arg1), arg(arg2)), defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
     

--- a/MockItYourselfTests/TestFixtures.swift
+++ b/MockItYourselfTests/TestFixtures.swift
@@ -11,25 +11,25 @@ import MockItYourself
 
 class ReturnValueClass {
     let value: Int
-    
+
     init(value: Int) {
         self.value = value
     }
 }
 
 protocol ExampleProtocol {
-    
+
     var property: String { get }
     var propertyImplicitlyUnwrapped: String! { get }
-    
+
     func methodThatIsNotMocked()
-    
+
     func methodWithOptionalArgument(_ arg1: String?)
-    
+
     func methodWithArgs0()
     func methodWithArgs0ReturnsOptional() -> String?
     func methodWithArgs0Returns() -> String
-    
+
     func methodWithArgs1(_ arg1: String)
     func methodWithArgs1ReturnsOptional(_ arg1: String) -> String?
     func methodWithArgs1Returns(_ arg1: String) -> String
@@ -39,25 +39,25 @@ protocol ExampleProtocol {
 
 class MockExampleClass: ExampleProtocol, MockItYourself {
     let callHandler = MockCallHandler()
-    
+
     static let defaultReturnValue = "default return value"
-    
+
     var property: String {
         return callHandler.registerCall(defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
-    
+
     var propertyOptional: String? {
         return callHandler.registerCall(defaultReturnValue: nil)
     }
-    
+
     var propertyImplicitlyUnwrapped: String! {
         return callHandler.registerCall(defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
-    
+
     func methodThatIsNotMocked() {
         //Not mocked method
     }
-    
+
     func methodWithOptionalArgument(_ arg1: String?) {
         callHandler.registerCall(args: Args1(arg(arg1)))
     }
@@ -65,35 +65,35 @@ class MockExampleClass: ExampleProtocol, MockItYourself {
     func methodWithArgs0() {
         callHandler.registerMethodCall()
     }
-    
+
     func methodWithArgs0ReturnsOptional() -> String? {
         return callHandler.registerCall(defaultReturnValue: nil)
     }
-    
+
     func methodWithArgs0Returns() -> String {
         return callHandler.registerCall(defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
-    
+
     func methodWithArgs1(_ arg1: String) {
         callHandler.registerCall(args: Args1(arg(arg1)))
     }
-    
+
     func methodWithArgs1ReturnsOptional(_ arg1: String) -> String? {
         return callHandler.registerCall(args: Args1(arg(arg1)), defaultReturnValue: nil)
     }
-    
-    func methodWithArgs1ReturnsClass(arg1: String) -> ReturnValueClass {
+
+    func methodWithArgs1ReturnsClass(_ arg1: String) -> ReturnValueClass {
         return callHandler.registerCall(args: Args1(arg(arg1)), defaultReturnValue: ReturnValueClass(value: 1))
     }
-    
+
     func methodWithArgs1Returns(_ arg1: String) -> String {
         return callHandler.registerCall(args: Args1(arg(arg1)), defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
-    
+
     func methodWithArgs2(_ arg1: String, arg2: Selector?) {
-        return callHandler.registerCall(args: Args2(arg(arg1), arg(arg2)), defaultReturnValue: MockExampleClass.defaultReturnValue)
+        callHandler.registerCall(args: Args2(arg(arg1), arg(arg2)))
     }
-    
+
     func methodWithArgs3(arg1: AnyObject?, arg2: Selector, arg3: Int) -> String {
         return callHandler.registerCall(args: Args3(arg(arg1), arg(arg2), arg(arg3)), defaultReturnValue: MockExampleClass.defaultReturnValue)
     }

--- a/MockItYourselfTests/TestFixtures.swift
+++ b/MockItYourselfTests/TestFixtures.swift
@@ -34,7 +34,7 @@ protocol ExampleProtocol {
     func methodWithArgs1ReturnsOptional(_ arg1: String) -> String?
     func methodWithArgs1Returns(_ arg1: String) -> String
 
-    func methodWithArgs2(_ arg1: String, arg2: Selector?) -> String
+    func methodWithArgs2(_ arg1: String, arg2: Selector?)
 }
 
 class MockExampleClass: ExampleProtocol, MockItYourself {
@@ -90,7 +90,7 @@ class MockExampleClass: ExampleProtocol, MockItYourself {
         return callHandler.registerCall(args: Args1(arg(arg1)), defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
     
-    func methodWithArgs2(_ arg1: String, arg2: Selector?) -> String {
+    func methodWithArgs2(_ arg1: String, arg2: Selector?) {
         return callHandler.registerCall(args: Args2(arg(arg1), arg(arg2)), defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
     

--- a/MockItYourselfTests/TestFixtures.swift
+++ b/MockItYourselfTests/TestFixtures.swift
@@ -63,7 +63,7 @@ class MockExampleClass: ExampleProtocol, MockItYourself {
     }
 
     func methodWithArgs0() {
-        callHandler.registerCall()
+        callHandler.registerMethodCall()
     }
     
     func methodWithArgs0ReturnsOptional() -> String? {

--- a/MockItYourselfTests/TestFixtures.swift
+++ b/MockItYourselfTests/TestFixtures.swift
@@ -33,8 +33,8 @@ protocol ExampleProtocol {
     func methodWithArgs1(_ arg1: String)
     func methodWithArgs1ReturnsOptional(_ arg1: String) -> String?
     func methodWithArgs1Returns(_ arg1: String) -> String
-    
-    func methodWithArgs2(_ arg1: AnyObject, arg2: Selector) -> String
+
+    func methodWithArgs2(_ arg1: String, arg2: Selector?) -> String
 }
 
 class MockExampleClass: ExampleProtocol, MockItYourself {
@@ -90,7 +90,7 @@ class MockExampleClass: ExampleProtocol, MockItYourself {
         return callHandler.registerCall(args: Args1(arg(arg1)), defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
     
-    func methodWithArgs2(_ arg1: AnyObject, arg2: Selector) -> String {
+    func methodWithArgs2(_ arg1: String, arg2: Selector?) -> String {
         return callHandler.registerCall(args: Args2(arg(arg1), arg(arg2)), defaultReturnValue: MockExampleClass.defaultReturnValue)
     }
     

--- a/MockItYourselfTests/VerifyTests.swift
+++ b/MockItYourselfTests/VerifyTests.swift
@@ -101,7 +101,7 @@ class VerifyTests: XCTestCase {
         mockExample.methodWithArgs2(arg1, arg2: arg2)
         mockExample.methodWithArgs2(arg1, arg2: arg2)
         
-        verify(mockExample, checkArguments: true, expectedCallCount: 2) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
+        verify(mockExample, expectedCallCount: 2, checkArguments: true) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
     }
     
     func test_asserts_if_checking_if_correct_arguments_with_expected_number_of_calls_if_call_number_mismatch() {
@@ -112,7 +112,7 @@ class VerifyTests: XCTestCase {
         
         var success = false
         do {
-            try mockExample.callHandler.verify(checkArguments: true, expectedCallCount: 2) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
+            try mockExample.callHandler.verify(expectedCallCount: 2, checkArguments: true) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
         } catch {
             success = true
         }
@@ -129,7 +129,7 @@ class VerifyTests: XCTestCase {
         
         var success = false
         do {
-            try mockExample.callHandler.verify(checkArguments: true, expectedCallCount: 2) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
+            try mockExample.callHandler.verify(expectedCallCount: 2, checkArguments: true) { self.mockExample.methodWithArgs2(arg1, arg2: arg2) }
         } catch {
             success = true
         }

--- a/MockItYourselfTests/VerifyTests.swift
+++ b/MockItYourselfTests/VerifyTests.swift
@@ -65,7 +65,7 @@ class VerifyTests: XCTestCase {
     
     func test_can_verify_method_was_called_ignoring_arguments() {
         let arg1 = "arg1"
-        let arg2: Selector = #selector(NSString.substringToIndex(_:))
+        let arg2: Selector = #selector(NSString.appending)
         
         mockExample.methodWithArgs2(arg1, arg2: arg2)
         
@@ -83,10 +83,11 @@ class VerifyTests: XCTestCase {
         
         XCTAssertTrue(success)
     }
-    
+
     func test_can_verify_method_call_and_check_if_correct_arguments() {
         let arg1 = "arg1"
-        let arg2: Selector = #selector(NSString.substringToIndex(_:))
+        let arg2: Selector = #selector(NSString.appending)
+
         
         mockExample.methodWithArgs2(arg1, arg2: arg2)
         
@@ -95,7 +96,7 @@ class VerifyTests: XCTestCase {
     
     func test_can_verify_method_call_and_check_if_correct_arguments_with_expected_number_of_calls() {
         let arg1 = "arg1"
-        let arg2: Selector = #selector(NSString.substringToIndex(_:))
+        let arg2: Selector = #selector(NSString.appending)
         
         mockExample.methodWithArgs2(arg1, arg2: arg2)
         mockExample.methodWithArgs2(arg1, arg2: arg2)
@@ -105,7 +106,7 @@ class VerifyTests: XCTestCase {
     
     func test_asserts_if_checking_if_correct_arguments_with_expected_number_of_calls_if_call_number_mismatch() {
         let arg1 = "arg1"
-        let arg2: Selector = #selector(NSString.substringToIndex(_:))
+        let arg2: Selector = #selector(NSString.appending)
         
         mockExample.methodWithArgs2(arg1, arg2: arg2)
         
@@ -121,7 +122,7 @@ class VerifyTests: XCTestCase {
     
     func test_asserts_if_checking_if_correct_arguments_with_expected_number_of_calls_if_one_call_has_different_arguments() {
         let arg1 = "arg1"
-        let arg2: Selector = #selector(NSString.substringToIndex(_:))
+        let arg2: Selector = #selector(NSString.appending)
         
         mockExample.methodWithArgs2(arg1, arg2: arg2)
         mockExample.methodWithArgs2("different argument", arg2: arg2)
@@ -146,7 +147,7 @@ class VerifyTests: XCTestCase {
     
     func test_verify_arguments_assert_if_method_is_not_called_at_all() {
         let arg1 = "arg1"
-        let arg2: Selector = #selector(NSString.substringToIndex(_:))
+        let arg2: Selector = #selector(NSString.appending)
         
         var success = false
         
@@ -161,7 +162,7 @@ class VerifyTests: XCTestCase {
 
     func test_verify_arguments_asserts_if_arguments_does_not_match() {
         let arg1 = "arg1"
-        let arg2: Selector = #selector(NSString.substringToIndex(_:))
+        let arg2: Selector = #selector(NSString.appending)
         
         mockExample.methodWithArgs2("", arg2: arg2)
         

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![License](https://img.shields.io/cocoapods/l/MockItYourself.svg?style=flat)](http://cocoapods.org/pods/MockItYourself)
 [![Platform](https://img.shields.io/cocoapods/p/MockItYourself.svg?style=flat)](http://cocoapods.org/pods/MockItYourself)
 
+
+Note: Be aware is the readme for Swift 3.0. See the branch `miy-swift-2.3` for Swift 2.3 documentation.
+
 `MockItYourself` is an attempt to create a mocking framework for Swift. Currently, you can't dynamically create classes in Swift and it is therefore impossible to create a powerful mocking framework like [OCMock](http://ocmock.org/). `MockItYourself` is an attempt to reduce the boilerplate needed to manually create mocks.
 
 `MockItYourself` is heavily inspired by [SwiftMock](https://github.com/mflint/SwiftMock) and could in some ways be considered a fork of that project.


### PR DESCRIPTION
## Description
This PR 
I wanted to try to keep the API similar to what we had before so its easier for projects to update the library, hence all of the unnamed parameters `_`.

We might think about switching to new swift api guidelines:https://swift.org/documentation/api-design-guidelines/  
Whats left before this can be merged
- [ ] Import in an example project and try out
 
## Checklist
- [x] Create seperate branch for Swift 2.3 in case hotfix is needed
- [ ] Documentation has been added or updated.
- [ ] All applicable classes have unit tests.
- [ ] This PR contains no commented out code.